### PR TITLE
Fix CD workflow: install deps before tsx

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,15 +20,15 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Get version from release
         id: get_version
         run: echo "VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/ui@//')" >> $GITHUB_OUTPUT
 
       - name: Update package version
         run: pnpm tsx scripts/version.ts ui ${{ steps.get_version.outputs.VERSION }}
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Build UI package
         run: |
@@ -65,15 +65,15 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Get version from release
         id: get_version
         run: echo "VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/hooks@//')" >> $GITHUB_OUTPUT
 
       - name: Update package version
         run: pnpm tsx scripts/version.ts hooks ${{ steps.get_version.outputs.VERSION }}
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Build Hooks package
         run: pnpm --filter @rhinolabs/react-hooks run build


### PR DESCRIPTION
## Summary

- Fixes the CD deployment failure where `pnpm tsx scripts/version.ts` fails with `Command "tsx" not found`
- Root cause: `tsx` is a devDependency that requires `pnpm install` to be available, but the install step ran **after** the version update step
- Moves `pnpm install` before `pnpm tsx` in both `publish-ui` and `publish-hooks` jobs

Fixes: https://github.com/rhinolabs/ui-toolkit/actions/runs/23095106998/job/67086189108

## Test plan

- [ ] Trigger a new release to verify the CD workflow completes successfully