### PR TITLE
Fix prefetch 503 errors: switch to static output

### DIFF
--- a/apps/docs/astro.config.mts
+++ b/apps/docs/astro.config.mts
@@ -3,7 +3,7 @@ import starlight from '@astrojs/starlight';
 import cloudflare from '@astrojs/cloudflare';
 
 export default defineConfig({
-  output: 'server',
+  output: 'static',
   adapter: cloudflare(),
   integrations: [
     starlight({


### PR DESCRIPTION
## Summary
Changed documentation site output from `server` (SSR) to `static` (pre-rendered). Cloudflare Workers was rejecting prefetch requests with 503 errors because they were treated as lower-priority. With static output, all 96 pages are pre-rendered as HTML at build time and served from the CDN edge, eliminating 503s and improving performance.

## Technical Details
- Astro 5 removed `hybrid` mode, so `static` is now the correct choice for content-only sites
- Build verified: all pages pre-render successfully
- No content or middleware changes needed; this is a pure configuration fix

## Benefits
✓ Eliminates prefetch 503s
✓ Faster page loads (CDN edge vs Worker)
✓ Lower Worker invocation cost
✓ Better caching at the edge