### PR TITLE
Add forwardRef to component wrappers

### DIFF
--- a/packages/ui/src/components/ui/accordion.tsx
+++ b/packages/ui/src/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDownIcon } from "lucide-react";
 
@@ -12,56 +12,54 @@ function Accordion({
 	return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
 }
 
-function AccordionItem({
-	className,
-	...props
-}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
-	return (
-		<AccordionPrimitive.Item
-			data-slot="accordion-item"
-			className={cn("border-b last:border-b-0", className)}
-			{...props}
-		/>
-	);
-}
+const AccordionItem = React.forwardRef<
+	React.ComponentRef<typeof AccordionPrimitive.Item>,
+	React.ComponentProps<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+	<AccordionPrimitive.Item
+		ref={ref}
+		data-slot="accordion-item"
+		className={cn("border-b last:border-b-0", className)}
+		{...props}
+	/>
+));
+AccordionItem.displayName = "AccordionItem";
 
-function AccordionTrigger({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
-	return (
-		<AccordionPrimitive.Header className="flex">
-			<AccordionPrimitive.Trigger
-				data-slot="accordion-trigger"
-				className={cn(
-					"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
-					className,
-				)}
-				{...props}
-			>
-				{children}
-				<ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
-			</AccordionPrimitive.Trigger>
-		</AccordionPrimitive.Header>
-	);
-}
-
-function AccordionContent({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
-	return (
-		<AccordionPrimitive.Content
-			data-slot="accordion-content"
-			className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+const AccordionTrigger = React.forwardRef<
+	React.ComponentRef<typeof AccordionPrimitive.Trigger>,
+	React.ComponentProps<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+	<AccordionPrimitive.Header className="flex">
+		<AccordionPrimitive.Trigger
+			ref={ref}
+			data-slot="accordion-trigger"
+			className={cn(
+				"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+				className,
+			)}
 			{...props}
 		>
-			<div className={cn("pt-0 pb-4", className)}>{children}</div>
-		</AccordionPrimitive.Content>
-	);
-}
+			{children}
+			<ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+		</AccordionPrimitive.Trigger>
+	</AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = "AccordionTrigger";
+
+const AccordionContent = React.forwardRef<
+	React.ComponentRef<typeof AccordionPrimitive.Content>,
+	React.ComponentProps<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+	<AccordionPrimitive.Content
+		ref={ref}
+		data-slot="accordion-content"
+		className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+		{...props}
+	>
+		<div className={cn("pt-0 pb-4", className)}>{children}</div>
+	</AccordionPrimitive.Content>
+));
+AccordionContent.displayName = "AccordionContent";
 
 Accordion.Item = AccordionItem;
 Accordion.Trigger = AccordionTrigger;

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
 import { cn } from "@/lib/utils";
@@ -12,13 +12,17 @@ function AlertDialog({
 	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
-function AlertDialogTrigger({
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-	return (
-		<AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-	);
-}
+const AlertDialogTrigger = React.forwardRef<
+	React.ComponentRef<typeof AlertDialogPrimitive.Trigger>,
+	React.ComponentProps<typeof AlertDialogPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<AlertDialogPrimitive.Trigger
+		ref={ref}
+		data-slot="alert-dialog-trigger"
+		{...props}
+	/>
+));
+AlertDialogTrigger.displayName = "AlertDialogTrigger";
 
 function AlertDialogPortal({
 	...props
@@ -28,119 +32,119 @@ function AlertDialogPortal({
 	);
 }
 
-function AlertDialogOverlay({
-	className,
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
-	return (
-		<AlertDialogPrimitive.Overlay
-			data-slot="alert-dialog-overlay"
+const AlertDialogOverlay = React.forwardRef<
+	React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
+	React.ComponentProps<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Overlay
+		ref={ref}
+		data-slot="alert-dialog-overlay"
+		className={cn(
+			"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+			className,
+		)}
+		{...props}
+	/>
+));
+AlertDialogOverlay.displayName = "AlertDialogOverlay";
+
+const AlertDialogContent = React.forwardRef<
+	React.ComponentRef<typeof AlertDialogPrimitive.Content>,
+	React.ComponentProps<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPortal>
+		<AlertDialogOverlay />
+		<AlertDialogPrimitive.Content
+			ref={ref}
+			data-slot="alert-dialog-content"
 			className={cn(
-				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+				"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 				className,
 			)}
 			{...props}
 		/>
-	);
-}
+	</AlertDialogPortal>
+));
+AlertDialogContent.displayName = "AlertDialogContent";
 
-function AlertDialogContent({
-	className,
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
-	return (
-		<AlertDialogPortal>
-			<AlertDialogOverlay />
-			<AlertDialogPrimitive.Content
-				data-slot="alert-dialog-content"
-				className={cn(
-					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-					className,
-				)}
-				{...props}
-			/>
-		</AlertDialogPortal>
-	);
-}
+const AlertDialogHeader = React.forwardRef<
+	HTMLDivElement,
+	React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		data-slot="alert-dialog-header"
+		className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+		{...props}
+	/>
+));
+AlertDialogHeader.displayName = "AlertDialogHeader";
 
-function AlertDialogHeader({
-	className,
-	...props
-}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="alert-dialog-header"
-			className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
-			{...props}
-		/>
-	);
-}
+const AlertDialogFooter = React.forwardRef<
+	HTMLDivElement,
+	React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		data-slot="alert-dialog-footer"
+		className={cn(
+			"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+			className,
+		)}
+		{...props}
+	/>
+));
+AlertDialogFooter.displayName = "AlertDialogFooter";
 
-function AlertDialogFooter({
-	className,
-	...props
-}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="alert-dialog-footer"
-			className={cn(
-				"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const AlertDialogTitle = React.forwardRef<
+	React.ComponentRef<typeof AlertDialogPrimitive.Title>,
+	React.ComponentProps<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Title
+		ref={ref}
+		data-slot="alert-dialog-title"
+		className={cn("text-lg font-semibold", className)}
+		{...props}
+	/>
+));
+AlertDialogTitle.displayName = "AlertDialogTitle";
 
-function AlertDialogTitle({
-	className,
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
-	return (
-		<AlertDialogPrimitive.Title
-			data-slot="alert-dialog-title"
-			className={cn("text-lg font-semibold", className)}
-			{...props}
-		/>
-	);
-}
+const AlertDialogDescription = React.forwardRef<
+	React.ComponentRef<typeof AlertDialogPrimitive.Description>,
+	React.ComponentProps<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Description
+		ref={ref}
+		data-slot="alert-dialog-description"
+		className={cn("text-muted-foreground text-sm", className)}
+		{...props}
+	/>
+));
+AlertDialogDescription.displayName = "AlertDialogDescription";
 
-function AlertDialogDescription({
-	className,
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
-	return (
-		<AlertDialogPrimitive.Description
-			data-slot="alert-dialog-description"
-			className={cn("text-muted-foreground text-sm", className)}
-			{...props}
-		/>
-	);
-}
+const AlertDialogAction = React.forwardRef<
+	React.ComponentRef<typeof AlertDialogPrimitive.Action>,
+	React.ComponentProps<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Action
+		ref={ref}
+		className={cn(buttonVariants(), className)}
+		{...props}
+	/>
+));
+AlertDialogAction.displayName = "AlertDialogAction";
 
-function AlertDialogAction({
-	className,
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
-	return (
-		<AlertDialogPrimitive.Action
-			className={cn(buttonVariants(), className)}
-			{...props}
-		/>
-	);
-}
-
-function AlertDialogCancel({
-	className,
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
-	return (
-		<AlertDialogPrimitive.Cancel
-			className={cn(buttonVariants({ variant: "outline" }), className)}
-			{...props}
-		/>
-	);
-}
+const AlertDialogCancel = React.forwardRef<
+	React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
+	React.ComponentProps<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+	<AlertDialogPrimitive.Cancel
+		ref={ref}
+		className={cn(buttonVariants({ variant: "outline" }), className)}
+		{...props}
+	/>
+));
+AlertDialogCancel.displayName = "AlertDialogCancel";
 
 // Attach subcomponents to Alert Dialog
 AlertDialog.Portal = AlertDialogPortal;

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
@@ -36,25 +36,24 @@ const buttonVariants = cva(
 	},
 );
 
-function Button({
-	className,
-	variant,
-	size,
-	asChild = false,
-	...props
-}: React.ComponentProps<"button"> &
-	VariantProps<typeof buttonVariants> & {
-		asChild?: boolean;
-	}) {
+const Button = React.forwardRef<
+	HTMLButtonElement,
+	React.ComponentProps<"button"> &
+		VariantProps<typeof buttonVariants> & {
+			asChild?: boolean;
+		}
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
 	const Comp = asChild ? Slot : "button";
 
 	return (
 		<Comp
+			ref={ref}
 			data-slot="button"
 			className={cn(buttonVariants({ variant, size, className }))}
 			{...props}
 		/>
 	);
-}
+});
+Button.displayName = "Button";
 
 export { Button, buttonVariants };

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -1,32 +1,32 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-function Checkbox({
-	className,
-	...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
-	return (
-		<CheckboxPrimitive.Root
-			data-slot="checkbox"
-			className={cn(
-				"peer border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 size-4 shrink-0 rounded-[4px] border shadow-xs transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:focus-visible:ring-0",
-				className,
-			)}
-			{...props}
+const Checkbox = React.forwardRef<
+	React.ComponentRef<typeof CheckboxPrimitive.Root>,
+	React.ComponentProps<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+	<CheckboxPrimitive.Root
+		ref={ref}
+		data-slot="checkbox"
+		className={cn(
+			"peer border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 size-4 shrink-0 rounded-[4px] border shadow-xs transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:focus-visible:ring-0",
+			className,
+		)}
+		{...props}
+	>
+		<CheckboxPrimitive.Indicator
+			data-slot="checkbox-indicator"
+			className="flex items-center justify-center text-current"
 		>
-			<CheckboxPrimitive.Indicator
-				data-slot="checkbox-indicator"
-				className="flex items-center justify-center text-current"
-			>
-				<CheckIcon className="size-3.5" />
-			</CheckboxPrimitive.Indicator>
-		</CheckboxPrimitive.Root>
-	);
-}
+			<CheckIcon className="size-3.5" />
+		</CheckboxPrimitive.Indicator>
+	</CheckboxPrimitive.Root>
+));
+Checkbox.displayName = "Checkbox";
 
 export { Checkbox };

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
 
 function Collapsible({
@@ -8,27 +9,29 @@ function Collapsible({
 	return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
-function CollapsibleTrigger({
-	...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
-	return (
-		<CollapsiblePrimitive.CollapsibleTrigger
-			data-slot="collapsible-trigger"
-			{...props}
-		/>
-	);
-}
+const CollapsibleTrigger = React.forwardRef<
+	React.ComponentRef<typeof CollapsiblePrimitive.CollapsibleTrigger>,
+	React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>
+>(({ ...props }, ref) => (
+	<CollapsiblePrimitive.CollapsibleTrigger
+		ref={ref}
+		data-slot="collapsible-trigger"
+		{...props}
+	/>
+));
+CollapsibleTrigger.displayName = "CollapsibleTrigger";
 
-function CollapsibleContent({
-	...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
-	return (
-		<CollapsiblePrimitive.CollapsibleContent
-			data-slot="collapsible-content"
-			{...props}
-		/>
-	);
-}
+const CollapsibleContent = React.forwardRef<
+	React.ComponentRef<typeof CollapsiblePrimitive.CollapsibleContent>,
+	React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>
+>(({ ...props }, ref) => (
+	<CollapsiblePrimitive.CollapsibleContent
+		ref={ref}
+		data-slot="collapsible-content"
+		{...props}
+	/>
+));
+CollapsibleContent.displayName = "CollapsibleContent";
 
 // Attach subcomponents to Collapsible
 Collapsible.Trigger = CollapsibleTrigger;

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
@@ -12,21 +12,29 @@ function ContextMenu({
 	return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
 }
 
-function ContextMenuTrigger({
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
-	return (
-		<ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
-	);
-}
+const ContextMenuTrigger = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.Trigger>,
+	React.ComponentProps<typeof ContextMenuPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<ContextMenuPrimitive.Trigger
+		ref={ref}
+		data-slot="context-menu-trigger"
+		{...props}
+	/>
+));
+ContextMenuTrigger.displayName = "ContextMenuTrigger";
 
-function ContextMenuGroup({
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
-	return (
-		<ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
-	);
-}
+const ContextMenuGroup = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.Group>,
+	React.ComponentProps<typeof ContextMenuPrimitive.Group>
+>(({ ...props }, ref) => (
+	<ContextMenuPrimitive.Group
+		ref={ref}
+		data-slot="context-menu-group"
+		{...props}
+	/>
+));
+ContextMenuGroup.displayName = "ContextMenuGroup";
 
 function ContextMenuPortal({
 	...props
@@ -53,185 +61,177 @@ function ContextMenuRadioGroup({
 	);
 }
 
-function ContextMenuSubTrigger({
-	className,
-	inset,
-	children,
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
-	inset?: boolean;
-}) {
-	return (
-		<ContextMenuPrimitive.SubTrigger
-			data-slot="context-menu-sub-trigger"
-			data-inset={inset}
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		>
-			{children}
-			<ChevronRightIcon className="ml-auto" />
-		</ContextMenuPrimitive.SubTrigger>
-	);
-}
+const ContextMenuSubTrigger = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.SubTrigger>,
+	React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+		inset?: boolean;
+	}
+>(({ className, inset, children, ...props }, ref) => (
+	<ContextMenuPrimitive.SubTrigger
+		ref={ref}
+		data-slot="context-menu-sub-trigger"
+		data-inset={inset}
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	>
+		{children}
+		<ChevronRightIcon className="ml-auto" />
+	</ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = "ContextMenuSubTrigger";
 
-function ContextMenuSubContent({
-	className,
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
-	return (
-		<ContextMenuPrimitive.SubContent
-			data-slot="context-menu-sub-content"
-			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const ContextMenuSubContent = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
+	React.ComponentProps<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+	<ContextMenuPrimitive.SubContent
+		ref={ref}
+		data-slot="context-menu-sub-content"
+		className={cn(
+			"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
+			className,
+		)}
+		{...props}
+	/>
+));
+ContextMenuSubContent.displayName = "ContextMenuSubContent";
 
-function ContextMenuContent({
-	className,
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
-	return (
-		<ContextMenuPrimitive.Portal>
-			<ContextMenuPrimitive.Content
-				data-slot="context-menu-content"
-				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
-					className,
-				)}
-				{...props}
-			/>
-		</ContextMenuPrimitive.Portal>
-	);
-}
-
-function ContextMenuItem({
-	className,
-	inset,
-	variant = "default",
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
-	inset?: boolean;
-	variant?: "default" | "destructive";
-}) {
-	return (
-		<ContextMenuPrimitive.Item
-			data-slot="context-menu-item"
-			data-inset={inset}
-			data-variant={variant}
+const ContextMenuContent = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.Content>,
+	React.ComponentProps<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+	<ContextMenuPrimitive.Portal>
+		<ContextMenuPrimitive.Content
+			ref={ref}
+			data-slot="context-menu-content"
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
 				className,
 			)}
 			{...props}
 		/>
-	);
-}
+	</ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = "ContextMenuContent";
 
-function ContextMenuCheckboxItem({
-	className,
-	children,
-	checked,
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) {
-	return (
-		<ContextMenuPrimitive.CheckboxItem
-			data-slot="context-menu-checkbox-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			checked={checked}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<ContextMenuPrimitive.ItemIndicator>
-					<CheckIcon className="size-4" />
-				</ContextMenuPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</ContextMenuPrimitive.CheckboxItem>
-	);
-}
+const ContextMenuItem = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.Item>,
+	React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+		inset?: boolean;
+		variant?: "default" | "destructive";
+	}
+>(({ className, inset, variant = "default", ...props }, ref) => (
+	<ContextMenuPrimitive.Item
+		ref={ref}
+		data-slot="context-menu-item"
+		data-inset={inset}
+		data-variant={variant}
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	/>
+));
+ContextMenuItem.displayName = "ContextMenuItem";
 
-function ContextMenuRadioItem({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
-	return (
-		<ContextMenuPrimitive.RadioItem
-			data-slot="context-menu-radio-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<ContextMenuPrimitive.ItemIndicator>
-					<CircleIcon className="size-2 fill-current" />
-				</ContextMenuPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</ContextMenuPrimitive.RadioItem>
-	);
-}
+const ContextMenuCheckboxItem = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.CheckboxItem>,
+	React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+	<ContextMenuPrimitive.CheckboxItem
+		ref={ref}
+		data-slot="context-menu-checkbox-item"
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		checked={checked}
+		{...props}
+	>
+		<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+			<ContextMenuPrimitive.ItemIndicator>
+				<CheckIcon className="size-4" />
+			</ContextMenuPrimitive.ItemIndicator>
+		</span>
+		{children}
+	</ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName = "ContextMenuCheckboxItem";
 
-function ContextMenuLabel({
-	className,
-	inset,
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
-	inset?: boolean;
-}) {
-	return (
-		<ContextMenuPrimitive.Label
-			data-slot="context-menu-label"
-			data-inset={inset}
-			className={cn(
-				"text-foreground px-2 py-1.5 text-sm font-semibold data-[inset]:pl-8",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const ContextMenuRadioItem = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.RadioItem>,
+	React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+	<ContextMenuPrimitive.RadioItem
+		ref={ref}
+		data-slot="context-menu-radio-item"
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	>
+		<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+			<ContextMenuPrimitive.ItemIndicator>
+				<CircleIcon className="size-2 fill-current" />
+			</ContextMenuPrimitive.ItemIndicator>
+		</span>
+		{children}
+	</ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = "ContextMenuRadioItem";
 
-function ContextMenuSeparator({
-	className,
-	...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
-	return (
-		<ContextMenuPrimitive.Separator
-			data-slot="context-menu-separator"
-			className={cn("bg-border -mx-1 my-1 h-px", className)}
-			{...props}
-		/>
-	);
-}
+const ContextMenuLabel = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.Label>,
+	React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+		inset?: boolean;
+	}
+>(({ className, inset, ...props }, ref) => (
+	<ContextMenuPrimitive.Label
+		ref={ref}
+		data-slot="context-menu-label"
+		data-inset={inset}
+		className={cn(
+			"text-foreground px-2 py-1.5 text-sm font-semibold data-[inset]:pl-8",
+			className,
+		)}
+		{...props}
+	/>
+));
+ContextMenuLabel.displayName = "ContextMenuLabel";
 
-function ContextMenuShortcut({
-	className,
-	...props
-}: React.ComponentProps<"span">) {
-	return (
-		<span
-			data-slot="context-menu-shortcut"
-			className={cn(
-				"text-muted-foreground ml-auto text-xs tracking-widest",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const ContextMenuSeparator = React.forwardRef<
+	React.ComponentRef<typeof ContextMenuPrimitive.Separator>,
+	React.ComponentProps<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+	<ContextMenuPrimitive.Separator
+		ref={ref}
+		data-slot="context-menu-separator"
+		className={cn("bg-border -mx-1 my-1 h-px", className)}
+		{...props}
+	/>
+));
+ContextMenuSeparator.displayName = "ContextMenuSeparator";
+
+const ContextMenuShortcut = React.forwardRef<
+	HTMLSpanElement,
+	React.ComponentProps<"span">
+>(({ className, ...props }, ref) => (
+	<span
+		ref={ref}
+		data-slot="context-menu-shortcut"
+		className={cn(
+			"text-muted-foreground ml-auto text-xs tracking-widest",
+			className,
+		)}
+		{...props}
+	/>
+));
+ContextMenuShortcut.displayName = "ContextMenuShortcut";
 
 // Attach subcomponents to ContextMenu
 ContextMenu.Trigger = ContextMenuTrigger;

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 
@@ -12,11 +12,13 @@ function Dialog({
 	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
-}
+const DialogTrigger = React.forwardRef<
+	React.ComponentRef<typeof DialogPrimitive.Trigger>,
+	React.ComponentProps<typeof DialogPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<DialogPrimitive.Trigger ref={ref} data-slot="dialog-trigger" {...props} />
+));
+DialogTrigger.displayName = "DialogTrigger";
 
 function DialogPortal({
 	...props
@@ -24,105 +26,112 @@ function DialogPortal({
 	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
-	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
-}
+const DialogClose = React.forwardRef<
+	React.ComponentRef<typeof DialogPrimitive.Close>,
+	React.ComponentProps<typeof DialogPrimitive.Close>
+>(({ ...props }, ref) => (
+	<DialogPrimitive.Close ref={ref} data-slot="dialog-close" {...props} />
+));
+DialogClose.displayName = "DialogClose";
 
-function DialogOverlay({
-	className,
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
-	return (
-		<DialogPrimitive.Overlay
-			data-slot="dialog-overlay"
+const DialogOverlay = React.forwardRef<
+	React.ComponentRef<typeof DialogPrimitive.Overlay>,
+	React.ComponentProps<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Overlay
+		ref={ref}
+		data-slot="dialog-overlay"
+		className={cn(
+			"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+			className,
+		)}
+		{...props}
+	/>
+));
+DialogOverlay.displayName = "DialogOverlay";
+
+const DialogContent = React.forwardRef<
+	React.ComponentRef<typeof DialogPrimitive.Content>,
+	React.ComponentProps<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+	<DialogPortal data-slot="dialog-portal">
+		<DialogOverlay />
+		<DialogPrimitive.Content
+			ref={ref}
+			data-slot="dialog-content"
 			className={cn(
-				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+				"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 				className,
 			)}
 			{...props}
-		/>
-	);
-}
+		>
+			{children}
+			<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+				<XIcon />
+				<span className="sr-only">Close</span>
+			</DialogPrimitive.Close>
+		</DialogPrimitive.Content>
+	</DialogPortal>
+));
+DialogContent.displayName = "DialogContent";
 
-function DialogContent({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
-	return (
-		<DialogPortal data-slot="dialog-portal">
-			<DialogOverlay />
-			<DialogPrimitive.Content
-				data-slot="dialog-content"
-				className={cn(
-					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-					className,
-				)}
-				{...props}
-			>
-				{children}
-				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-					<XIcon />
-					<span className="sr-only">Close</span>
-				</DialogPrimitive.Close>
-			</DialogPrimitive.Content>
-		</DialogPortal>
-	);
-}
+const DialogHeader = React.forwardRef<
+	HTMLDivElement,
+	React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		data-slot="dialog-header"
+		className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+		{...props}
+	/>
+));
+DialogHeader.displayName = "DialogHeader";
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="dialog-header"
-			className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
-			{...props}
-		/>
-	);
-}
+const DialogFooter = React.forwardRef<
+	HTMLDivElement,
+	React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		data-slot="dialog-footer"
+		className={cn(
+			"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+			className,
+		)}
+		{...props}
+	/>
+));
+DialogFooter.displayName = "DialogFooter";
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="dialog-footer"
-			className={cn(
-				"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const DialogTitle = React.forwardRef<
+	React.ComponentRef<typeof DialogPrimitive.Title>,
+	React.ComponentProps<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Title
+		ref={ref}
+		data-slot="dialog-title"
+		className={cn(
+			"text-lg leading-none font-semibold tracking-tight",
+			className,
+		)}
+		{...props}
+	/>
+));
+DialogTitle.displayName = "DialogTitle";
 
-function DialogTitle({
-	className,
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
-	return (
-		<DialogPrimitive.Title
-			data-slot="dialog-title"
-			className={cn(
-				"text-lg leading-none font-semibold tracking-tight",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
-
-function DialogDescription({
-	className,
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
-	return (
-		<DialogPrimitive.Description
-			data-slot="dialog-description"
-			className={cn("text-muted-foreground text-sm", className)}
-			{...props}
-		/>
-	);
-}
+const DialogDescription = React.forwardRef<
+	React.ComponentRef<typeof DialogPrimitive.Description>,
+	React.ComponentProps<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Description
+		ref={ref}
+		data-slot="dialog-description"
+		className={cn("text-muted-foreground text-sm", className)}
+		{...props}
+	/>
+));
+DialogDescription.displayName = "DialogDescription";
 
 // Attach subcomponents to Dialog
 Dialog.Trigger = DialogTrigger;

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
@@ -20,93 +20,93 @@ function DropdownMenuPortal({
 	);
 }
 
-function DropdownMenuTrigger({
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-	return (
-		<DropdownMenuPrimitive.Trigger
-			data-slot="dropdown-menu-trigger"
-			{...props}
-		/>
-	);
-}
+const DropdownMenuTrigger = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<DropdownMenuPrimitive.Trigger
+		ref={ref}
+		data-slot="dropdown-menu-trigger"
+		{...props}
+	/>
+));
+DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
 
-function DropdownMenuContent({
-	className,
-	sideOffset = 4,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
-	return (
-		<DropdownMenuPrimitive.Portal>
-			<DropdownMenuPrimitive.Content
-				data-slot="dropdown-menu-content"
-				sideOffset={sideOffset}
-				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
-					className,
-				)}
-				{...props}
-			/>
-		</DropdownMenuPrimitive.Portal>
-	);
-}
-
-function DropdownMenuGroup({
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-	return (
-		<DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-	);
-}
-
-function DropdownMenuItem({
-	className,
-	inset,
-	variant = "default",
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-	inset?: boolean;
-	variant?: "default" | "destructive";
-}) {
-	return (
-		<DropdownMenuPrimitive.Item
-			data-slot="dropdown-menu-item"
-			data-inset={inset}
-			data-variant={variant}
+const DropdownMenuContent = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+	<DropdownMenuPrimitive.Portal>
+		<DropdownMenuPrimitive.Content
+			ref={ref}
+			data-slot="dropdown-menu-content"
+			sideOffset={sideOffset}
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
 				className,
 			)}
 			{...props}
 		/>
-	);
-}
+	</DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = "DropdownMenuContent";
 
-function DropdownMenuCheckboxItem({
-	className,
-	children,
-	checked,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
-	return (
-		<DropdownMenuPrimitive.CheckboxItem
-			data-slot="dropdown-menu-checkbox-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			checked={checked}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<DropdownMenuPrimitive.ItemIndicator>
-					<CheckIcon className="size-4" />
-				</DropdownMenuPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</DropdownMenuPrimitive.CheckboxItem>
-	);
-}
+const DropdownMenuGroup = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.Group>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.Group>
+>(({ ...props }, ref) => (
+	<DropdownMenuPrimitive.Group
+		ref={ref}
+		data-slot="dropdown-menu-group"
+		{...props}
+	/>
+));
+DropdownMenuGroup.displayName = "DropdownMenuGroup";
+
+const DropdownMenuItem = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+		inset?: boolean;
+		variant?: "default" | "destructive";
+	}
+>(({ className, inset, variant = "default", ...props }, ref) => (
+	<DropdownMenuPrimitive.Item
+		ref={ref}
+		data-slot="dropdown-menu-item"
+		data-inset={inset}
+		data-variant={variant}
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	/>
+));
+DropdownMenuItem.displayName = "DropdownMenuItem";
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+	<DropdownMenuPrimitive.CheckboxItem
+		ref={ref}
+		data-slot="dropdown-menu-checkbox-item"
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		checked={checked}
+		{...props}
+	>
+		<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+			<DropdownMenuPrimitive.ItemIndicator>
+				<CheckIcon className="size-4" />
+			</DropdownMenuPrimitive.ItemIndicator>
+		</span>
+		{children}
+	</DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = "DropdownMenuCheckboxItem";
 
 function DropdownMenuRadioGroup({
 	...props
@@ -119,78 +119,76 @@ function DropdownMenuRadioGroup({
 	);
 }
 
-function DropdownMenuRadioItem({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
-	return (
-		<DropdownMenuPrimitive.RadioItem
-			data-slot="dropdown-menu-radio-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<DropdownMenuPrimitive.ItemIndicator>
-					<CircleIcon className="size-2 fill-current" />
-				</DropdownMenuPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</DropdownMenuPrimitive.RadioItem>
-	);
-}
+const DropdownMenuRadioItem = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+	<DropdownMenuPrimitive.RadioItem
+		ref={ref}
+		data-slot="dropdown-menu-radio-item"
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	>
+		<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+			<DropdownMenuPrimitive.ItemIndicator>
+				<CircleIcon className="size-2 fill-current" />
+			</DropdownMenuPrimitive.ItemIndicator>
+		</span>
+		{children}
+	</DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = "DropdownMenuRadioItem";
 
-function DropdownMenuLabel({
-	className,
-	inset,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-	inset?: boolean;
-}) {
-	return (
-		<DropdownMenuPrimitive.Label
-			data-slot="dropdown-menu-label"
-			data-inset={inset}
-			className={cn(
-				"px-2 py-1.5 text-sm font-semibold data-[inset]:pl-8",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const DropdownMenuLabel = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+		inset?: boolean;
+	}
+>(({ className, inset, ...props }, ref) => (
+	<DropdownMenuPrimitive.Label
+		ref={ref}
+		data-slot="dropdown-menu-label"
+		data-inset={inset}
+		className={cn(
+			"px-2 py-1.5 text-sm font-semibold data-[inset]:pl-8",
+			className,
+		)}
+		{...props}
+	/>
+));
+DropdownMenuLabel.displayName = "DropdownMenuLabel";
 
-function DropdownMenuSeparator({
-	className,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
-	return (
-		<DropdownMenuPrimitive.Separator
-			data-slot="dropdown-menu-separator"
-			className={cn("bg-border -mx-1 my-1 h-px", className)}
-			{...props}
-		/>
-	);
-}
+const DropdownMenuSeparator = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+	<DropdownMenuPrimitive.Separator
+		ref={ref}
+		data-slot="dropdown-menu-separator"
+		className={cn("bg-border -mx-1 my-1 h-px", className)}
+		{...props}
+	/>
+));
+DropdownMenuSeparator.displayName = "DropdownMenuSeparator";
 
-function DropdownMenuShortcut({
-	className,
-	...props
-}: React.ComponentProps<"span">) {
-	return (
-		<span
-			data-slot="dropdown-menu-shortcut"
-			className={cn(
-				"text-muted-foreground ml-auto text-xs tracking-widest",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const DropdownMenuShortcut = React.forwardRef<
+	HTMLSpanElement,
+	React.ComponentProps<"span">
+>(({ className, ...props }, ref) => (
+	<span
+		ref={ref}
+		data-slot="dropdown-menu-shortcut"
+		className={cn(
+			"text-muted-foreground ml-auto text-xs tracking-widest",
+			className,
+		)}
+		{...props}
+	/>
+));
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 function DropdownMenuSub({
 	...props
@@ -198,45 +196,43 @@ function DropdownMenuSub({
 	return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
-function DropdownMenuSubTrigger({
-	className,
-	inset,
-	children,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-	inset?: boolean;
-}) {
-	return (
-		<DropdownMenuPrimitive.SubTrigger
-			data-slot="dropdown-menu-sub-trigger"
-			data-inset={inset}
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
-				className,
-			)}
-			{...props}
-		>
-			{children}
-			<ChevronRightIcon className="ml-auto size-4" />
-		</DropdownMenuPrimitive.SubTrigger>
-	);
-}
+const DropdownMenuSubTrigger = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+		inset?: boolean;
+	}
+>(({ className, inset, children, ...props }, ref) => (
+	<DropdownMenuPrimitive.SubTrigger
+		ref={ref}
+		data-slot="dropdown-menu-sub-trigger"
+		data-inset={inset}
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+			className,
+		)}
+		{...props}
+	>
+		{children}
+		<ChevronRightIcon className="ml-auto size-4" />
+	</DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = "DropdownMenuSubTrigger";
 
-function DropdownMenuSubContent({
-	className,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
-	return (
-		<DropdownMenuPrimitive.SubContent
-			data-slot="dropdown-menu-sub-content"
-			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const DropdownMenuSubContent = React.forwardRef<
+	React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
+	React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+	<DropdownMenuPrimitive.SubContent
+		ref={ref}
+		data-slot="dropdown-menu-sub-content"
+		className={cn(
+			"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
+			className,
+		)}
+		{...props}
+	/>
+));
+DropdownMenuSubContent.displayName = "DropdownMenuSubContent";
 
 // Attach subcomponents to DropdownMenu
 DropdownMenu.Portal = DropdownMenuPortal;

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
 import { cn } from "@/lib/utils";
@@ -11,35 +11,37 @@ function HoverCard({
 	return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
 }
 
-function HoverCardTrigger({
-	...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
-	return (
-		<HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
-	);
-}
+const HoverCardTrigger = React.forwardRef<
+	React.ComponentRef<typeof HoverCardPrimitive.Trigger>,
+	React.ComponentProps<typeof HoverCardPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<HoverCardPrimitive.Trigger
+		ref={ref}
+		data-slot="hover-card-trigger"
+		{...props}
+	/>
+));
+HoverCardTrigger.displayName = "HoverCardTrigger";
 
-function HoverCardContent({
-	className,
-	align = "center",
-	sideOffset = 4,
-	...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
-	return (
-		<HoverCardPrimitive.Portal data-slot="hover-card-portal">
-			<HoverCardPrimitive.Content
-				data-slot="hover-card-content"
-				align={align}
-				sideOffset={sideOffset}
-				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-					className,
-				)}
-				{...props}
-			/>
-		</HoverCardPrimitive.Portal>
-	);
-}
+const HoverCardContent = React.forwardRef<
+	React.ComponentRef<typeof HoverCardPrimitive.Content>,
+	React.ComponentProps<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+	<HoverCardPrimitive.Portal data-slot="hover-card-portal">
+		<HoverCardPrimitive.Content
+			ref={ref}
+			data-slot="hover-card-content"
+			align={align}
+			sideOffset={sideOffset}
+			className={cn(
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+				className,
+			)}
+			{...props}
+		/>
+	</HoverCardPrimitive.Portal>
+));
+HoverCardContent.displayName = "HoverCardContent";
 
 // Attach subcomponents to Hover Card
 HoverCard.Trigger = HoverCardTrigger;

--- a/packages/ui/src/components/ui/menubar.tsx
+++ b/packages/ui/src/components/ui/menubar.tsx
@@ -69,22 +69,27 @@ MenubarTrigger.displayName = "MenubarTrigger";
 const MenubarContent = React.forwardRef<
 	React.ComponentRef<typeof MenubarPrimitive.Content>,
 	React.ComponentProps<typeof MenubarPrimitive.Content>
->(({ className, align = "start", alignOffset = -4, sideOffset = 8, ...props }, ref) => (
-	<MenubarPortal>
-		<MenubarPrimitive.Content
-			ref={ref}
-			data-slot="menubar-content"
-			align={align}
-			alignOffset={alignOffset}
-			sideOffset={sideOffset}
-			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-48 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
-				className,
-			)}
-			{...props}
-		/>
-	</MenubarPortal>
-));
+>(
+	(
+		{ className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
+		ref,
+	) => (
+		<MenubarPortal>
+			<MenubarPrimitive.Content
+				ref={ref}
+				data-slot="menubar-content"
+				align={align}
+				alignOffset={alignOffset}
+				sideOffset={sideOffset}
+				className={cn(
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-48 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
+					className,
+				)}
+				{...props}
+			/>
+		</MenubarPortal>
+	),
+);
 MenubarContent.displayName = "MenubarContent";
 
 const MenubarItem = React.forwardRef<
@@ -165,10 +170,7 @@ const MenubarLabel = React.forwardRef<
 		ref={ref}
 		data-slot="menubar-label"
 		data-inset={inset}
-		className={cn(
-			"px-2 py-1.5 text-sm font-medium data-inset:pl-8",
-			className,
-		)}
+		className={cn("px-2 py-1.5 text-sm font-medium data-inset:pl-8", className)}
 		{...props}
 	/>
 ));

--- a/packages/ui/src/components/ui/menubar.tsx
+++ b/packages/ui/src/components/ui/menubar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as MenubarPrimitive from "@radix-ui/react-menubar";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
@@ -28,11 +28,13 @@ function MenubarMenu({
 	return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />;
 }
 
-function MenubarGroup({
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.Group>) {
-	return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />;
-}
+const MenubarGroup = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.Group>,
+	React.ComponentProps<typeof MenubarPrimitive.Group>
+>(({ ...props }, ref) => (
+	<MenubarPrimitive.Group ref={ref} data-slot="menubar-group" {...props} />
+));
+MenubarGroup.displayName = "MenubarGroup";
 
 function MenubarPortal({
 	...props
@@ -48,167 +50,158 @@ function MenubarRadioGroup({
 	);
 }
 
-function MenubarTrigger({
-	className,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.Trigger>) {
-	return (
-		<MenubarPrimitive.Trigger
-			data-slot="menubar-trigger"
+const MenubarTrigger = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.Trigger>,
+	React.ComponentProps<typeof MenubarPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+	<MenubarPrimitive.Trigger
+		ref={ref}
+		data-slot="menubar-trigger"
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none",
+			className,
+		)}
+		{...props}
+	/>
+));
+MenubarTrigger.displayName = "MenubarTrigger";
+
+const MenubarContent = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.Content>,
+	React.ComponentProps<typeof MenubarPrimitive.Content>
+>(({ className, align = "start", alignOffset = -4, sideOffset = 8, ...props }, ref) => (
+	<MenubarPortal>
+		<MenubarPrimitive.Content
+			ref={ref}
+			data-slot="menubar-content"
+			align={align}
+			alignOffset={alignOffset}
+			sideOffset={sideOffset}
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none",
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-48 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
 				className,
 			)}
 			{...props}
 		/>
-	);
-}
+	</MenubarPortal>
+));
+MenubarContent.displayName = "MenubarContent";
 
-function MenubarContent({
-	className,
-	align = "start",
-	alignOffset = -4,
-	sideOffset = 8,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.Content>) {
-	return (
-		<MenubarPortal>
-			<MenubarPrimitive.Content
-				data-slot="menubar-content"
-				align={align}
-				alignOffset={alignOffset}
-				sideOffset={sideOffset}
-				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-48 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
-					className,
-				)}
-				{...props}
-			/>
-		</MenubarPortal>
-	);
-}
+const MenubarItem = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.Item>,
+	React.ComponentProps<typeof MenubarPrimitive.Item> & {
+		inset?: boolean;
+		variant?: "default" | "destructive";
+	}
+>(({ className, inset, variant = "default", ...props }, ref) => (
+	<MenubarPrimitive.Item
+		ref={ref}
+		data-slot="menubar-item"
+		data-inset={inset}
+		data-variant={variant}
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive! [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	/>
+));
+MenubarItem.displayName = "MenubarItem";
 
-function MenubarItem({
-	className,
-	inset,
-	variant = "default",
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.Item> & {
-	inset?: boolean;
-	variant?: "default" | "destructive";
-}) {
-	return (
-		<MenubarPrimitive.Item
-			data-slot="menubar-item"
-			data-inset={inset}
-			data-variant={variant}
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive! [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const MenubarCheckboxItem = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.CheckboxItem>,
+	React.ComponentProps<typeof MenubarPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+	<MenubarPrimitive.CheckboxItem
+		ref={ref}
+		data-slot="menubar-checkbox-item"
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		checked={checked}
+		{...props}
+	>
+		<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+			<MenubarPrimitive.ItemIndicator>
+				<CheckIcon className="size-4" />
+			</MenubarPrimitive.ItemIndicator>
+		</span>
+		{children}
+	</MenubarPrimitive.CheckboxItem>
+));
+MenubarCheckboxItem.displayName = "MenubarCheckboxItem";
 
-function MenubarCheckboxItem({
-	className,
-	children,
-	checked,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.CheckboxItem>) {
-	return (
-		<MenubarPrimitive.CheckboxItem
-			data-slot="menubar-checkbox-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			checked={checked}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<MenubarPrimitive.ItemIndicator>
-					<CheckIcon className="size-4" />
-				</MenubarPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</MenubarPrimitive.CheckboxItem>
-	);
-}
+const MenubarRadioItem = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.RadioItem>,
+	React.ComponentProps<typeof MenubarPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+	<MenubarPrimitive.RadioItem
+		ref={ref}
+		data-slot="menubar-radio-item"
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	>
+		<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+			<MenubarPrimitive.ItemIndicator>
+				<CircleIcon className="size-2 fill-current" />
+			</MenubarPrimitive.ItemIndicator>
+		</span>
+		{children}
+	</MenubarPrimitive.RadioItem>
+));
+MenubarRadioItem.displayName = "MenubarRadioItem";
 
-function MenubarRadioItem({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.RadioItem>) {
-	return (
-		<MenubarPrimitive.RadioItem
-			data-slot="menubar-radio-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<MenubarPrimitive.ItemIndicator>
-					<CircleIcon className="size-2 fill-current" />
-				</MenubarPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</MenubarPrimitive.RadioItem>
-	);
-}
+const MenubarLabel = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.Label>,
+	React.ComponentProps<typeof MenubarPrimitive.Label> & {
+		inset?: boolean;
+	}
+>(({ className, inset, ...props }, ref) => (
+	<MenubarPrimitive.Label
+		ref={ref}
+		data-slot="menubar-label"
+		data-inset={inset}
+		className={cn(
+			"px-2 py-1.5 text-sm font-medium data-inset:pl-8",
+			className,
+		)}
+		{...props}
+	/>
+));
+MenubarLabel.displayName = "MenubarLabel";
 
-function MenubarLabel({
-	className,
-	inset,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.Label> & {
-	inset?: boolean;
-}) {
-	return (
-		<MenubarPrimitive.Label
-			data-slot="menubar-label"
-			data-inset={inset}
-			className={cn(
-				"px-2 py-1.5 text-sm font-medium data-inset:pl-8",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const MenubarSeparator = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.Separator>,
+	React.ComponentProps<typeof MenubarPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+	<MenubarPrimitive.Separator
+		ref={ref}
+		data-slot="menubar-separator"
+		className={cn("bg-border -mx-1 my-1 h-px", className)}
+		{...props}
+	/>
+));
+MenubarSeparator.displayName = "MenubarSeparator";
 
-function MenubarSeparator({
-	className,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.Separator>) {
-	return (
-		<MenubarPrimitive.Separator
-			data-slot="menubar-separator"
-			className={cn("bg-border -mx-1 my-1 h-px", className)}
-			{...props}
-		/>
-	);
-}
-
-function MenubarShortcut({
-	className,
-	...props
-}: React.ComponentProps<"span">) {
-	return (
-		<span
-			data-slot="menubar-shortcut"
-			className={cn(
-				"text-muted-foreground ml-auto text-xs tracking-widest",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const MenubarShortcut = React.forwardRef<
+	HTMLSpanElement,
+	React.ComponentProps<"span">
+>(({ className, ...props }, ref) => (
+	<span
+		ref={ref}
+		data-slot="menubar-shortcut"
+		className={cn(
+			"text-muted-foreground ml-auto text-xs tracking-widest",
+			className,
+		)}
+		{...props}
+	/>
+));
+MenubarShortcut.displayName = "MenubarShortcut";
 
 function MenubarSub({
 	...props
@@ -216,45 +209,43 @@ function MenubarSub({
 	return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />;
 }
 
-function MenubarSubTrigger({
-	className,
-	inset,
-	children,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.SubTrigger> & {
-	inset?: boolean;
-}) {
-	return (
-		<MenubarPrimitive.SubTrigger
-			data-slot="menubar-sub-trigger"
-			data-inset={inset}
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-inset:pl-8",
-				className,
-			)}
-			{...props}
-		>
-			{children}
-			<ChevronRightIcon className="ml-auto h-4 w-4" />
-		</MenubarPrimitive.SubTrigger>
-	);
-}
+const MenubarSubTrigger = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.SubTrigger>,
+	React.ComponentProps<typeof MenubarPrimitive.SubTrigger> & {
+		inset?: boolean;
+	}
+>(({ className, inset, children, ...props }, ref) => (
+	<MenubarPrimitive.SubTrigger
+		ref={ref}
+		data-slot="menubar-sub-trigger"
+		data-inset={inset}
+		className={cn(
+			"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-inset:pl-8",
+			className,
+		)}
+		{...props}
+	>
+		{children}
+		<ChevronRightIcon className="ml-auto h-4 w-4" />
+	</MenubarPrimitive.SubTrigger>
+));
+MenubarSubTrigger.displayName = "MenubarSubTrigger";
 
-function MenubarSubContent({
-	className,
-	...props
-}: React.ComponentProps<typeof MenubarPrimitive.SubContent>) {
-	return (
-		<MenubarPrimitive.SubContent
-			data-slot="menubar-sub-content"
-			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const MenubarSubContent = React.forwardRef<
+	React.ComponentRef<typeof MenubarPrimitive.SubContent>,
+	React.ComponentProps<typeof MenubarPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+	<MenubarPrimitive.SubContent
+		ref={ref}
+		data-slot="menubar-sub-content"
+		className={cn(
+			"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+			className,
+		)}
+		{...props}
+	/>
+));
+MenubarSubContent.displayName = "MenubarSubContent";
 
 Menubar.Portal = MenubarPortal;
 Menubar.Menu = MenubarMenu;

--- a/packages/ui/src/components/ui/navigation-menu.tsx
+++ b/packages/ui/src/components/ui/navigation-menu.tsx
@@ -103,9 +103,7 @@ const NavigationMenuViewport = React.forwardRef<
 	React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
 	<div
-		className={cn(
-			"absolute top-full left-0 isolate z-50 flex justify-center",
-		)}
+		className={cn("absolute top-full left-0 isolate z-50 flex justify-center")}
 	>
 		<NavigationMenuPrimitive.Viewport
 			ref={ref}

--- a/packages/ui/src/components/ui/navigation-menu.tsx
+++ b/packages/ui/src/components/ui/navigation-menu.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
@@ -29,131 +29,130 @@ function NavigationMenu({
 	);
 }
 
-function NavigationMenuList({
-	className,
-	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
-	return (
-		<NavigationMenuPrimitive.List
-			data-slot="navigation-menu-list"
-			className={cn(
-				"group flex flex-1 list-none items-center justify-center gap-1",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const NavigationMenuList = React.forwardRef<
+	React.ComponentRef<typeof NavigationMenuPrimitive.List>,
+	React.ComponentProps<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+	<NavigationMenuPrimitive.List
+		ref={ref}
+		data-slot="navigation-menu-list"
+		className={cn(
+			"group flex flex-1 list-none items-center justify-center gap-1",
+			className,
+		)}
+		{...props}
+	/>
+));
+NavigationMenuList.displayName = "NavigationMenuList";
 
-function NavigationMenuItem({
-	className,
-	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
-	return (
-		<NavigationMenuPrimitive.Item
-			data-slot="navigation-menu-item"
-			className={cn("relative", className)}
-			{...props}
-		/>
-	);
-}
+const NavigationMenuItem = React.forwardRef<
+	React.ComponentRef<typeof NavigationMenuPrimitive.Item>,
+	React.ComponentProps<typeof NavigationMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+	<NavigationMenuPrimitive.Item
+		ref={ref}
+		data-slot="navigation-menu-item"
+		className={cn("relative", className)}
+		{...props}
+	/>
+));
+NavigationMenuItem.displayName = "NavigationMenuItem";
 
 const navigationMenuTriggerStyle = cva(
 	"group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1",
 );
 
-function NavigationMenuTrigger({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
-	return (
-		<NavigationMenuPrimitive.Trigger
-			data-slot="navigation-menu-trigger"
-			className={cn(navigationMenuTriggerStyle(), "group", className)}
-			{...props}
-		>
-			{children}{" "}
-			<ChevronDownIcon
-				className="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-				aria-hidden="true"
-			/>
-		</NavigationMenuPrimitive.Trigger>
-	);
-}
+const NavigationMenuTrigger = React.forwardRef<
+	React.ComponentRef<typeof NavigationMenuPrimitive.Trigger>,
+	React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+	<NavigationMenuPrimitive.Trigger
+		ref={ref}
+		data-slot="navigation-menu-trigger"
+		className={cn(navigationMenuTriggerStyle(), "group", className)}
+		{...props}
+	>
+		{children}{" "}
+		<ChevronDownIcon
+			className="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+			aria-hidden="true"
+		/>
+	</NavigationMenuPrimitive.Trigger>
+));
+NavigationMenuTrigger.displayName = "NavigationMenuTrigger";
 
-function NavigationMenuContent({
-	className,
-	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
-	return (
-		<NavigationMenuPrimitive.Content
-			data-slot="navigation-menu-content"
+const NavigationMenuContent = React.forwardRef<
+	React.ComponentRef<typeof NavigationMenuPrimitive.Content>,
+	React.ComponentProps<typeof NavigationMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+	<NavigationMenuPrimitive.Content
+		ref={ref}
+		data-slot="navigation-menu-content"
+		className={cn(
+			"data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
+			"group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
+			className,
+		)}
+		{...props}
+	/>
+));
+NavigationMenuContent.displayName = "NavigationMenuContent";
+
+const NavigationMenuViewport = React.forwardRef<
+	React.ComponentRef<typeof NavigationMenuPrimitive.Viewport>,
+	React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+	<div
+		className={cn(
+			"absolute top-full left-0 isolate z-50 flex justify-center",
+		)}
+	>
+		<NavigationMenuPrimitive.Viewport
+			ref={ref}
+			data-slot="navigation-menu-viewport"
 			className={cn(
-				"data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
-				"group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
+				"origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border shadow md:w-(--radix-navigation-menu-viewport-width)",
 				className,
 			)}
 			{...props}
 		/>
-	);
-}
+	</div>
+));
+NavigationMenuViewport.displayName = "NavigationMenuViewport";
 
-function NavigationMenuViewport({
-	className,
-	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
-	return (
-		<div
-			className={cn(
-				"absolute top-full left-0 isolate z-50 flex justify-center",
-			)}
-		>
-			<NavigationMenuPrimitive.Viewport
-				data-slot="navigation-menu-viewport"
-				className={cn(
-					"origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border shadow md:w-(--radix-navigation-menu-viewport-width)",
-					className,
-				)}
-				{...props}
-			/>
-		</div>
-	);
-}
+const NavigationMenuLink = React.forwardRef<
+	React.ComponentRef<typeof NavigationMenuPrimitive.Link>,
+	React.ComponentProps<typeof NavigationMenuPrimitive.Link>
+>(({ className, ...props }, ref) => (
+	<NavigationMenuPrimitive.Link
+		ref={ref}
+		data-slot="navigation-menu-link"
+		className={cn(
+			"data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	/>
+));
+NavigationMenuLink.displayName = "NavigationMenuLink";
 
-function NavigationMenuLink({
-	className,
-	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
-	return (
-		<NavigationMenuPrimitive.Link
-			data-slot="navigation-menu-link"
-			className={cn(
-				"data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
-
-function NavigationMenuIndicator({
-	className,
-	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
-	return (
-		<NavigationMenuPrimitive.Indicator
-			data-slot="navigation-menu-indicator"
-			className={cn(
-				"data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-1 flex h-1.5 items-end justify-center overflow-hidden",
-				className,
-			)}
-			{...props}
-		>
-			<div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
-		</NavigationMenuPrimitive.Indicator>
-	);
-}
+const NavigationMenuIndicator = React.forwardRef<
+	React.ComponentRef<typeof NavigationMenuPrimitive.Indicator>,
+	React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>
+>(({ className, ...props }, ref) => (
+	<NavigationMenuPrimitive.Indicator
+		ref={ref}
+		data-slot="navigation-menu-indicator"
+		className={cn(
+			"data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-1 flex h-1.5 items-end justify-center overflow-hidden",
+			className,
+		)}
+		{...props}
+	>
+		<div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
+	</NavigationMenuPrimitive.Indicator>
+));
+NavigationMenuIndicator.displayName = "NavigationMenuIndicator";
 
 NavigationMenu.List = NavigationMenuList;
 NavigationMenu.Item = NavigationMenuItem;

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { cn } from "@/lib/utils";
@@ -11,39 +11,41 @@ function Popover({
 	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({
-	...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
-}
+const PopoverTrigger = React.forwardRef<
+	React.ComponentRef<typeof PopoverPrimitive.Trigger>,
+	React.ComponentProps<typeof PopoverPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<PopoverPrimitive.Trigger ref={ref} data-slot="popover-trigger" {...props} />
+));
+PopoverTrigger.displayName = "PopoverTrigger";
 
-function PopoverContent({
-	className,
-	align = "center",
-	sideOffset = 4,
-	...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
-	return (
-		<PopoverPrimitive.Portal>
-			<PopoverPrimitive.Content
-				data-slot="popover-content"
-				align={align}
-				sideOffset={sideOffset}
-				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-hidden",
-					className,
-				)}
-				{...props}
-			/>
-		</PopoverPrimitive.Portal>
-	);
-}
+const PopoverContent = React.forwardRef<
+	React.ComponentRef<typeof PopoverPrimitive.Content>,
+	React.ComponentProps<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+	<PopoverPrimitive.Portal>
+		<PopoverPrimitive.Content
+			ref={ref}
+			data-slot="popover-content"
+			align={align}
+			sideOffset={sideOffset}
+			className={cn(
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-hidden",
+				className,
+			)}
+			{...props}
+		/>
+	</PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = "PopoverContent";
 
-function PopoverAnchor({
-	...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
-}
+const PopoverAnchor = React.forwardRef<
+	React.ComponentRef<typeof PopoverPrimitive.Anchor>,
+	React.ComponentProps<typeof PopoverPrimitive.Anchor>
+>(({ ...props }, ref) => (
+	<PopoverPrimitive.Anchor ref={ref} data-slot="popover-anchor" {...props} />
+));
+PopoverAnchor.displayName = "PopoverAnchor";
 
 // Attach subcomponents to Popover
 Popover.Trigger = PopoverTrigger;

--- a/packages/ui/src/components/ui/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { CircleIcon } from "lucide-react";
 
@@ -19,28 +19,28 @@ function RadioGroup({
 	);
 }
 
-function RadioGroupItem({
-	className,
-	...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
-	return (
-		<RadioGroupPrimitive.Item
-			data-slot="radio-group-item"
-			className={cn(
-				"border-input text-primary ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:focus-visible:ring-0",
-				className,
-			)}
-			{...props}
+const RadioGroupItem = React.forwardRef<
+	React.ComponentRef<typeof RadioGroupPrimitive.Item>,
+	React.ComponentProps<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+	<RadioGroupPrimitive.Item
+		ref={ref}
+		data-slot="radio-group-item"
+		className={cn(
+			"border-input text-primary ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:focus-visible:ring-0",
+			className,
+		)}
+		{...props}
+	>
+		<RadioGroupPrimitive.Indicator
+			data-slot="radio-group-indicator"
+			className="relative flex items-center justify-center"
 		>
-			<RadioGroupPrimitive.Indicator
-				data-slot="radio-group-indicator"
-				className="relative flex items-center justify-center"
-			>
-				<CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
-			</RadioGroupPrimitive.Indicator>
-		</RadioGroupPrimitive.Item>
-	);
-}
+			<CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+		</RadioGroupPrimitive.Indicator>
+	</RadioGroupPrimitive.Item>
+));
+RadioGroupItem.displayName = "RadioGroupItem";
 
 // Attach subcomponents to RadioGroup
 RadioGroup.Item = RadioGroupItem;

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -30,90 +30,89 @@ function SelectGroup({
 	return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-function SelectValue({
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
-	return <SelectPrimitive.Value data-slot="select-value" {...props} />;
-}
+const SelectValue = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.Value>,
+	React.ComponentProps<typeof SelectPrimitive.Value>
+>(({ ...props }, ref) => (
+	<SelectPrimitive.Value ref={ref} data-slot="select-value" {...props} />
+));
+SelectValue.displayName = "SelectValue";
 
-function SelectTrigger({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
-	return (
-		<SelectPrimitive.Trigger
-			data-slot="select-trigger"
+const SelectTrigger = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.Trigger>,
+	React.ComponentProps<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+	<SelectPrimitive.Trigger
+		ref={ref}
+		data-slot="select-trigger"
+		className={cn(
+			"border-input data-[placeholder]:text-muted-foreground aria-invalid:border-destructive ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-4 focus-visible:outline-1 [&_svg:not([class*='text-'])]:text-muted-foreground flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:line-clamp-1",
+			className,
+		)}
+		{...props}
+	>
+		{children}
+		<SelectPrimitive.Icon asChild>
+			<ChevronDownIcon className="size-4 opacity-50" />
+		</SelectPrimitive.Icon>
+	</SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = "SelectTrigger";
+
+const SelectContent = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.Content>,
+	React.ComponentProps<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+	<SelectPrimitive.Portal>
+		<SelectPrimitive.Content
+			ref={ref}
+			data-slot="select-content"
 			className={cn(
-				"border-input data-[placeholder]:text-muted-foreground aria-invalid:border-destructive ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-4 focus-visible:outline-1 [&_svg:not([class*='text-'])]:text-muted-foreground flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:line-clamp-1",
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+				position === "popper" &&
+					"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
 				className,
 			)}
+			position={position}
 			{...props}
 		>
-			{children}
-			<SelectPrimitive.Icon asChild>
-				<ChevronDownIcon className="size-4 opacity-50" />
-			</SelectPrimitive.Icon>
-		</SelectPrimitive.Trigger>
-	);
-}
-
-function SelectContent({
-	className,
-	children,
-	position = "popper",
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
-	return (
-		<SelectPrimitive.Portal>
-			<SelectPrimitive.Content
-				data-slot="select-content"
+			<SelectScrollUpButton />
+			<SelectPrimitive.Viewport
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+					"p-1",
 					position === "popper" &&
-						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-					className,
+						"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
 				)}
-				position={position}
-				{...props}
 			>
-				<SelectScrollUpButton />
-				<SelectPrimitive.Viewport
-					className={cn(
-						"p-1",
-						position === "popper" &&
-							"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
-					)}
-				>
-					{children}
-				</SelectPrimitive.Viewport>
-				<SelectScrollDownButton />
-			</SelectPrimitive.Content>
-		</SelectPrimitive.Portal>
-	);
-}
+				{children}
+			</SelectPrimitive.Viewport>
+			<SelectScrollDownButton />
+		</SelectPrimitive.Content>
+	</SelectPrimitive.Portal>
+));
+SelectContent.displayName = "SelectContent";
 
-function SelectLabel({
-	className,
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.Label>) {
-	return (
-		<SelectPrimitive.Label
-			data-slot="select-label"
-			className={cn("px-2 py-1.5 text-sm font-semibold", className)}
-			{...props}
-		/>
-	);
-}
+const SelectLabel = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.Label>,
+	React.ComponentProps<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+	<SelectPrimitive.Label
+		ref={ref}
+		data-slot="select-label"
+		className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+		{...props}
+	/>
+));
+SelectLabel.displayName = "SelectLabel";
 
-function SelectItem({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+const SelectItem = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.Item>,
+	React.ComponentProps<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => {
 	const { showCheckIcon } = React.useContext(SelectContext);
 	return (
 		<SelectPrimitive.Item
+			ref={ref}
 			data-slot="select-item"
 			className={cn(
 				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
@@ -131,56 +130,57 @@ function SelectItem({
 			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
 		</SelectPrimitive.Item>
 	);
-}
+});
+SelectItem.displayName = "SelectItem";
 
-function SelectSeparator({
-	className,
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
-	return (
-		<SelectPrimitive.Separator
-			data-slot="select-separator"
-			className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
-			{...props}
-		/>
-	);
-}
+const SelectSeparator = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.Separator>,
+	React.ComponentProps<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+	<SelectPrimitive.Separator
+		ref={ref}
+		data-slot="select-separator"
+		className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+		{...props}
+	/>
+));
+SelectSeparator.displayName = "SelectSeparator";
 
-function SelectScrollUpButton({
-	className,
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
-	return (
-		<SelectPrimitive.ScrollUpButton
-			data-slot="select-scroll-up-button"
-			className={cn(
-				"flex cursor-default items-center justify-center py-1",
-				className,
-			)}
-			{...props}
-		>
-			<ChevronUpIcon className="size-4" />
-		</SelectPrimitive.ScrollUpButton>
-	);
-}
+const SelectScrollUpButton = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
+	React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+	<SelectPrimitive.ScrollUpButton
+		ref={ref}
+		data-slot="select-scroll-up-button"
+		className={cn(
+			"flex cursor-default items-center justify-center py-1",
+			className,
+		)}
+		{...props}
+	>
+		<ChevronUpIcon className="size-4" />
+	</SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = "SelectScrollUpButton";
 
-function SelectScrollDownButton({
-	className,
-	...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
-	return (
-		<SelectPrimitive.ScrollDownButton
-			data-slot="select-scroll-down-button"
-			className={cn(
-				"flex cursor-default items-center justify-center py-1",
-				className,
-			)}
-			{...props}
-		>
-			<ChevronDownIcon className="size-4" />
-		</SelectPrimitive.ScrollDownButton>
-	);
-}
+const SelectScrollDownButton = React.forwardRef<
+	React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
+	React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+	<SelectPrimitive.ScrollDownButton
+		ref={ref}
+		data-slot="select-scroll-down-button"
+		className={cn(
+			"flex cursor-default items-center justify-center py-1",
+			className,
+		)}
+		{...props}
+	>
+		<ChevronDownIcon className="size-4" />
+	</SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = "SelectScrollDownButton";
 
 // Attach subcomponents to Select
 Select.Content = SelectContent;

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 
@@ -10,17 +10,21 @@ function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
 	return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
-function SheetTrigger({
-	...props
-}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
-	return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
-}
+const SheetTrigger = React.forwardRef<
+	React.ComponentRef<typeof SheetPrimitive.Trigger>,
+	React.ComponentProps<typeof SheetPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<SheetPrimitive.Trigger ref={ref} data-slot="sheet-trigger" {...props} />
+));
+SheetTrigger.displayName = "SheetTrigger";
 
-function SheetClose({
-	...props
-}: React.ComponentProps<typeof SheetPrimitive.Close>) {
-	return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
-}
+const SheetClose = React.forwardRef<
+	React.ComponentRef<typeof SheetPrimitive.Close>,
+	React.ComponentProps<typeof SheetPrimitive.Close>
+>(({ ...props }, ref) => (
+	<SheetPrimitive.Close ref={ref} data-slot="sheet-close" {...props} />
+));
+SheetClose.displayName = "SheetClose";
 
 function SheetPortal({
 	...props
@@ -28,104 +32,108 @@ function SheetPortal({
 	return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
-function SheetOverlay({
-	className,
-	...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
-	return (
-		<SheetPrimitive.Overlay
-			data-slot="sheet-overlay"
+const SheetOverlay = React.forwardRef<
+	React.ComponentRef<typeof SheetPrimitive.Overlay>,
+	React.ComponentProps<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<SheetPrimitive.Overlay
+		ref={ref}
+		data-slot="sheet-overlay"
+		className={cn(
+			"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+			className,
+		)}
+		{...props}
+	/>
+));
+SheetOverlay.displayName = "SheetOverlay";
+
+const SheetContent = React.forwardRef<
+	React.ComponentRef<typeof SheetPrimitive.Content>,
+	React.ComponentProps<typeof SheetPrimitive.Content> & {
+		side?: "top" | "right" | "bottom" | "left";
+	}
+>(({ className, children, side = "right", ...props }, ref) => (
+	<SheetPortal>
+		<SheetOverlay />
+		<SheetPrimitive.Content
+			ref={ref}
+			data-slot="sheet-content"
 			className={cn(
-				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+				"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+				side === "right" &&
+					"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+				side === "left" &&
+					"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+				side === "top" &&
+					"data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+				side === "bottom" &&
+					"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
 				className,
 			)}
 			{...props}
-		/>
-	);
-}
+		>
+			{children}
+			<SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+				<XIcon className="size-4" />
+				<span className="sr-only">Close</span>
+			</SheetPrimitive.Close>
+		</SheetPrimitive.Content>
+	</SheetPortal>
+));
+SheetContent.displayName = "SheetContent";
 
-function SheetContent({
-	className,
-	children,
-	side = "right",
-	...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
-	side?: "top" | "right" | "bottom" | "left";
-}) {
-	return (
-		<SheetPortal>
-			<SheetOverlay />
-			<SheetPrimitive.Content
-				data-slot="sheet-content"
-				className={cn(
-					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
-					side === "right" &&
-						"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
-					side === "left" &&
-						"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
-					side === "top" &&
-						"data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
-					side === "bottom" &&
-						"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
-					className,
-				)}
-				{...props}
-			>
-				{children}
-				<SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-					<XIcon className="size-4" />
-					<span className="sr-only">Close</span>
-				</SheetPrimitive.Close>
-			</SheetPrimitive.Content>
-		</SheetPortal>
-	);
-}
+const SheetHeader = React.forwardRef<
+	HTMLDivElement,
+	React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		data-slot="sheet-header"
+		className={cn("flex flex-col gap-1.5 p-4", className)}
+		{...props}
+	/>
+));
+SheetHeader.displayName = "SheetHeader";
 
-function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="sheet-header"
-			className={cn("flex flex-col gap-1.5 p-4", className)}
-			{...props}
-		/>
-	);
-}
+const SheetFooter = React.forwardRef<
+	HTMLDivElement,
+	React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		data-slot="sheet-footer"
+		className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+		{...props}
+	/>
+));
+SheetFooter.displayName = "SheetFooter";
 
-function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="sheet-footer"
-			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
-			{...props}
-		/>
-	);
-}
+const SheetTitle = React.forwardRef<
+	React.ComponentRef<typeof SheetPrimitive.Title>,
+	React.ComponentProps<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<SheetPrimitive.Title
+		ref={ref}
+		data-slot="sheet-title"
+		className={cn("text-foreground font-semibold tracking-tight", className)}
+		{...props}
+	/>
+));
+SheetTitle.displayName = "SheetTitle";
 
-function SheetTitle({
-	className,
-	...props
-}: React.ComponentProps<typeof SheetPrimitive.Title>) {
-	return (
-		<SheetPrimitive.Title
-			data-slot="sheet-title"
-			className={cn("text-foreground font-semibold tracking-tight", className)}
-			{...props}
-		/>
-	);
-}
-
-function SheetDescription({
-	className,
-	...props
-}: React.ComponentProps<typeof SheetPrimitive.Description>) {
-	return (
-		<SheetPrimitive.Description
-			data-slot="sheet-description"
-			className={cn("text-muted-foreground text-sm", className)}
-			{...props}
-		/>
-	);
-}
+const SheetDescription = React.forwardRef<
+	React.ComponentRef<typeof SheetPrimitive.Description>,
+	React.ComponentProps<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<SheetPrimitive.Description
+		ref={ref}
+		data-slot="sheet-description"
+		className={cn("text-muted-foreground text-sm", className)}
+		{...props}
+	/>
+));
+SheetDescription.displayName = "SheetDescription";
 
 // Attach subcomponents to Sheet
 Sheet.Trigger = SheetTrigger;

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -1,31 +1,31 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as SwitchPrimitive from "@radix-ui/react-switch";
 
 import { cn } from "@/lib/utils";
 
-function Switch({
-	className,
-	...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
-	return (
-		<SwitchPrimitive.Root
-			data-slot="switch"
+const Switch = React.forwardRef<
+	React.ComponentRef<typeof SwitchPrimitive.Root>,
+	React.ComponentProps<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+	<SwitchPrimitive.Root
+		ref={ref}
+		data-slot="switch"
+		className={cn(
+			"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-hidden focus-visible:outline-1 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:focus-visible:ring-0",
+			className,
+		)}
+		{...props}
+	>
+		<SwitchPrimitive.Thumb
+			data-slot="switch-thumb"
 			className={cn(
-				"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-hidden focus-visible:outline-1 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:focus-visible:ring-0",
-				className,
+				"bg-background pointer-events-none block size-4 rounded-full ring-0 shadow-lg transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
 			)}
-			{...props}
-		>
-			<SwitchPrimitive.Thumb
-				data-slot="switch-thumb"
-				className={cn(
-					"bg-background pointer-events-none block size-4 rounded-full ring-0 shadow-lg transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
-				)}
-			/>
-		</SwitchPrimitive.Root>
-	);
-}
+		/>
+	</SwitchPrimitive.Root>
+));
+Switch.displayName = "Switch";
 
 export { Switch };

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 
 import { cn } from "@/lib/utils";
@@ -18,53 +18,53 @@ function Tabs({
 	);
 }
 
-function TabsList({
-	className,
-	...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
-	return (
-		<TabsPrimitive.List
-			data-slot="tabs-list"
-			className={cn(
-				"bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-1",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const TabsList = React.forwardRef<
+	React.ComponentRef<typeof TabsPrimitive.List>,
+	React.ComponentProps<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+	<TabsPrimitive.List
+		ref={ref}
+		data-slot="tabs-list"
+		className={cn(
+			"bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-1",
+			className,
+		)}
+		{...props}
+	/>
+));
+TabsList.displayName = "TabsList";
 
-function TabsTrigger({
-	className,
-	...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
-	return (
-		<TabsPrimitive.Trigger
-			data-slot="tabs-trigger"
-			className={cn(
-				"data-[state=active]:bg-background data-[state=active]:text-foreground ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 inline-flex items-center justify-center gap-2 rounded-md px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 aria-invalid:focus-visible:ring-0 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const TabsTrigger = React.forwardRef<
+	React.ComponentRef<typeof TabsPrimitive.Trigger>,
+	React.ComponentProps<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+	<TabsPrimitive.Trigger
+		ref={ref}
+		data-slot="tabs-trigger"
+		className={cn(
+			"data-[state=active]:bg-background data-[state=active]:text-foreground ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 inline-flex items-center justify-center gap-2 rounded-md px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 aria-invalid:focus-visible:ring-0 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+			className,
+		)}
+		{...props}
+	/>
+));
+TabsTrigger.displayName = "TabsTrigger";
 
-function TabsContent({
-	className,
-	...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
-	return (
-		<TabsPrimitive.Content
-			data-slot="tabs-content"
-			className={cn(
-				"ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 flex-1 transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 aria-invalid:focus-visible:ring-0",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+const TabsContent = React.forwardRef<
+	React.ComponentRef<typeof TabsPrimitive.Content>,
+	React.ComponentProps<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+	<TabsPrimitive.Content
+		ref={ref}
+		data-slot="tabs-content"
+		className={cn(
+			"ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 flex-1 transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 aria-invalid:focus-visible:ring-0",
+			className,
+		)}
+		{...props}
+	/>
+));
+TabsContent.displayName = "TabsContent";
 
 // Attach subcomponents to Tabs
 Tabs.List = TabsList;

--- a/packages/ui/src/components/ui/toggle-group.tsx
+++ b/packages/ui/src/components/ui/toggle-group.tsx
@@ -40,18 +40,16 @@ function ToggleGroup({
 	);
 }
 
-function ToggleGroupItem({
-	className,
-	children,
-	variant,
-	size,
-	...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
-	VariantProps<typeof toggleVariants>) {
+const ToggleGroupItem = React.forwardRef<
+	React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
+	React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+		VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
 	const context = React.useContext(ToggleGroupContext);
 
 	return (
 		<ToggleGroupPrimitive.Item
+			ref={ref}
 			data-slot="toggle-group-item"
 			data-variant={context.variant || variant}
 			data-size={context.size || size}
@@ -68,7 +66,8 @@ function ToggleGroupItem({
 			{children}
 		</ToggleGroupPrimitive.Item>
 	);
-}
+});
+ToggleGroupItem.displayName = "ToggleGroupItem";
 
 // Attach subcomponents to ToggleGroup
 ToggleGroup.Item = ToggleGroupItem;

--- a/packages/ui/src/components/ui/toggle.tsx
+++ b/packages/ui/src/components/ui/toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";
 
@@ -28,20 +28,18 @@ const toggleVariants = cva(
 	},
 );
 
-function Toggle({
-	className,
-	variant,
-	size,
-	...props
-}: React.ComponentProps<typeof TogglePrimitive.Root> &
-	VariantProps<typeof toggleVariants>) {
-	return (
-		<TogglePrimitive.Root
-			data-slot="toggle"
-			className={cn(toggleVariants({ variant, size, className }))}
-			{...props}
-		/>
-	);
-}
+const Toggle = React.forwardRef<
+	React.ComponentRef<typeof TogglePrimitive.Root>,
+	React.ComponentProps<typeof TogglePrimitive.Root> &
+		VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+	<TogglePrimitive.Root
+		ref={ref}
+		data-slot="toggle"
+		className={cn(toggleVariants({ variant, size, className }))}
+		{...props}
+	/>
+));
+Toggle.displayName = "Toggle";
 
 export { Toggle, toggleVariants };

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 import { cn } from "@/lib/utils";
@@ -28,35 +28,35 @@ function Tooltip({
 	);
 }
 
-function TooltipTrigger({
-	...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-	return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
-}
+const TooltipTrigger = React.forwardRef<
+	React.ComponentRef<typeof TooltipPrimitive.Trigger>,
+	React.ComponentProps<typeof TooltipPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<TooltipPrimitive.Trigger ref={ref} data-slot="tooltip-trigger" {...props} />
+));
+TooltipTrigger.displayName = "TooltipTrigger";
 
-function TooltipContent({
-	className,
-	sideOffset = 4,
-	children,
-	...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
-	return (
-		<TooltipPrimitive.Portal>
-			<TooltipPrimitive.Content
-				data-slot="tooltip-content"
-				sideOffset={sideOffset}
-				className={cn(
-					"bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-w-sm rounded-md px-3 py-1.5 text-xs",
-					className,
-				)}
-				{...props}
-			>
-				{children}
-				<TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
-			</TooltipPrimitive.Content>
-		</TooltipPrimitive.Portal>
-	);
-}
+const TooltipContent = React.forwardRef<
+	React.ComponentRef<typeof TooltipPrimitive.Content>,
+	React.ComponentProps<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, children, ...props }, ref) => (
+	<TooltipPrimitive.Portal>
+		<TooltipPrimitive.Content
+			ref={ref}
+			data-slot="tooltip-content"
+			sideOffset={sideOffset}
+			className={cn(
+				"bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-w-sm rounded-md px-3 py-1.5 text-xs",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+		</TooltipPrimitive.Content>
+	</TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = "TooltipContent";
 
 // Attach subcomponents to Tooltip
 Tooltip.Provider = TooltipProvider;


### PR DESCRIPTION
## Summary

Added `React.forwardRef` to 80+ component wrappers across 20 UI component files to enable ref forwarding with Radix UI's `asChild` prop. This fixes the composition pattern where components like `Button`, `DropdownMenuTrigger`, and `DialogTrigger` are used as children of Radix components with `asChild={true}`.

When `asChild` is used, Radix internally calls `composeRefs()` to forward its refs onto child components. Without `forwardRef`, these refs were silently dropped, causing issues like Popper positioning failures and console warnings.

**Affected components:** Button, DropdownMenu (10 subs), Dialog (6 subs), Popover, Tooltip, AlertDialog (6 subs), Sheet (5 subs), Select (8 subs), Tabs (3 subs), Accordion (3 subs), ContextMenu (10 subs), Menubar (11 subs), HoverCard (2 subs), NavigationMenu (7 subs), Collapsible, Checkbox, RadioGroup (2 subs), Switch, Toggle, ToggleGroup (2 subs).

**Provider/portal components remain as functions** (e.g., DropdownMenu root, DialogPortal) since they don't render DOM and don't benefit from ref forwarding.

## Fixes

- [#85](https://github.com/rhinolabs/ui-toolkit/issues/85) Component wrappers don't forward refs, breaking Radix asChild composition

## React 18/19 Compatibility

`forwardRef` works across React 18 and 19 (not removed in 19, just optional). This maintains compatibility with the current `react: ^18.0.0` peer dependency.